### PR TITLE
Add Rules to ordering

### DIFF
--- a/cft/format/sort.go
+++ b/cft/format/sort.go
@@ -19,6 +19,7 @@ var orders = ordering{
 		"Conditions",
 		"Transform",
 		"Globals",
+		"Rules",
 		"Resources",
 		"Outputs",
 	},


### PR DESCRIPTION
Issue #, if available:
No Issue

Description of changes:
We currently have Rules in our CloudFormation template. It looks like, since this isn't included in the ordering, it automatically get's pushed at the bottom of the file. 

It would be nice to see Rules being consistently placed in the same position in the template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
